### PR TITLE
Fix arbitrary vault_path when several entity_rid_mappings share a canonical

### DIFF
--- a/api/personal_ingest_api.py
+++ b/api/personal_ingest_api.py
@@ -67,6 +67,69 @@ def _vault_note_exists(rel_path: Optional[str]) -> bool:
     return (_VAULT_ROOT / f"{rel}.md").exists() or (_VAULT_ROOT / rel).exists()
 
 
+def _pick_best_mapping(rows, expected_folder: Optional[str] = None) -> Optional[str]:
+    """Choose one vault_path among entity_rid_mappings rows sharing a canonical.
+
+    Several rows can share one canonical_uri because /register-entity upserts on
+    ``ON CONFLICT (vault_rid)``: registering a second note for an entity that
+    already has one inserts a NEW row instead of repointing the old one. Renames
+    and duplicate-note consolidation both produce this.
+
+    The old query was a bare ``LIMIT 1`` with no ORDER BY, so Postgres returned
+    an arbitrary (in practice oldest) row. Observed 2026-07-16: canonical
+    person-marie-gauthier-1bb78735e78e had mappings to both People/Marie.md (a
+    deleted-then-sync-restored duplicate, created 2026-03) and the live
+    People/Marie Gauthier.md, and the stale loser won on age — so resolution and
+    --propagate both wrote to the wrong note.
+
+    Preference order, highest first:
+      1. the note actually exists on disk (a mapping to a missing file is dead);
+      2. the note sits in the folder for the entity's OWN type — Regenerate
+         Cascadia is an Organization, so Organizations/ beats Projects/. Without
+         this, same-name cross-type pairs (Regenerate Cascadia, PKOLS, KOI,
+         SeaTrees, Scott Morris) tie on name and fall through to recency, which
+         is arbitrary and silently flips the answer;
+      3. the mapping's recorded name matches the canonical entity's name
+         ("Marie Gauthier" beats "Marie" for canonical "Marie Gauthier");
+      4. most recently synced — the caller orders rows accordingly, and max()
+         keeps the first maximal element, so recency is the natural tiebreak.
+
+    (2) and (3) are independent: Marie's duplicates are both in People/ and are
+    separated by name; Regenerate Cascadia's both match on name and are
+    separated by folder.
+
+    Note (1) is fail-safe: when the vault isn't mounted _vault_note_exists
+    returns True for every row, collapsing this to the later signals rather than
+    discarding all candidates. expected_folder=None likewise just skips (2).
+    """
+    if not rows:
+        return None
+
+    def comparable(value: Optional[str]) -> Optional[str]:
+        # normalize_entity_text collapses runs of spaces with a single
+        # non-idempotent .replace('  ', ' '), so 'a   b' survives as 'a  b'.
+        # Collapse here rather than changing that shared normalizer, whose
+        # semantics the whole resolution stack depends on.
+        if not value:
+            return None
+        return " ".join(normalize_entity_text(value).split())
+
+    def rank(row):
+        path = row["vault_path"] or ""
+        exists = _vault_note_exists(path)
+        folder_match = bool(
+            expected_folder and path.startswith(f"{expected_folder}/")
+        )
+        canonical_name = comparable(row.get("canonical_name"))
+        mapping_name = comparable(row.get("name"))
+        name_match = bool(
+            canonical_name and mapping_name and mapping_name == canonical_name
+        )
+        return (exists, folder_match, name_match)
+
+    return max(rows, key=rank)["vault_path"]
+
+
 # Import CAT receipt chain
 from api.cat_receipts import create_receipt, generate_receipt_id, get_receipt_chain
 
@@ -2983,31 +3046,37 @@ async def _annotate_vault_fields(
 
     - vault_path: from the entity_rid_mappings row (public/local scope only;
       node_private mappings are excluded). One indexed lookup on the existing
-      idx_rid_mappings_canonical index. Null when there is no mapping.
+      idx_rid_mappings_canonical index. Null when there is no mapping. When more
+      than one mapping shares the canonical, _pick_best_mapping decides — see
+      that helper for why duplicates exist and how the winner is chosen.
     - vault_note_exists: best-effort filesystem check via _vault_note_exists
       (True when the vault isn't mounted here — see that helper). False when
       there is no mapping.
     - vault_folder: the schema folder for the entity type (e.g. Person ->
       People). Null when entity_type is missing.
     """
-    vault_path = None
-    if canonical_uri:
-        vault_path = await conn.fetchval(
-            """
-            SELECT vault_path FROM entity_rid_mappings
-            WHERE canonical_uri = $1
-              AND COALESCE(visibility_scope, 'public') != 'node_private'
-            LIMIT 1
-            """,
-            canonical_uri,
-        )
-    vault_note_exists = _vault_note_exists(vault_path) if vault_path else False
     vault_folder = None
     if entity_type:
         try:
             vault_folder = get_schema_for_type(entity_type).folder
         except Exception:
             vault_folder = None
+
+    vault_path = None
+    if canonical_uri:
+        rows = await conn.fetch(
+            """
+            SELECT erm.vault_path, erm.name, er.entity_text AS canonical_name
+            FROM entity_rid_mappings erm
+            LEFT JOIN entity_registry er ON er.fuseki_uri = erm.canonical_uri
+            WHERE erm.canonical_uri = $1
+              AND COALESCE(erm.visibility_scope, 'public') != 'node_private'
+            ORDER BY erm.last_synced DESC NULLS LAST, erm.id DESC
+            """,
+            canonical_uri,
+        )
+        vault_path = _pick_best_mapping(rows, vault_folder)
+    vault_note_exists = _vault_note_exists(vault_path) if vault_path else False
     return vault_path, vault_note_exists, vault_folder
 
 
@@ -3875,6 +3944,37 @@ async def register_vault_entity(request: RegisterEntityRequest):
                     request.content_hash,
                     request.visibility_scope or "public"
                 )
+
+                # Prune sibling mappings for this canonical whose note is gone.
+                # The upsert above conflicts on vault_rid, so registering a
+                # second note for an existing canonical INSERTs rather than
+                # repointing — leaving the old row to compete forever (that is
+                # how People/Marie.md kept beating People/Marie Gauthier.md).
+                # Only rows whose file no longer exists are removed: two LIVE
+                # notes on one canonical is a real ambiguity for the operator,
+                # surfaced as the collision warning, not something to silently
+                # resolve by deletion. _vault_note_exists is fail-safe (True
+                # when the vault isn't mounted), so a headless deploy prunes
+                # nothing. document_entity_links hang off canonical_uri, not
+                # these rows, so pruning never drops links.
+                sibling_rows = await conn.fetch(
+                    """
+                    SELECT vault_rid, vault_path FROM entity_rid_mappings
+                    WHERE canonical_uri = $1 AND vault_rid != $2
+                    """,
+                    canonical.uri, eff_vault_rid,
+                )
+                for sibling in sibling_rows:
+                    if _vault_note_exists(sibling["vault_path"]):
+                        continue
+                    await conn.execute(
+                        "DELETE FROM entity_rid_mappings WHERE vault_rid = $1",
+                        sibling["vault_rid"],
+                    )
+                    logger.info(
+                        "Pruned stale mapping %s -> %s (note missing) for %s",
+                        sibling["vault_rid"], sibling["vault_path"], canonical.uri,
+                    )
 
                 # Update entity_registry with vault_rid if not set
                 await conn.execute("""

--- a/scripts/split_false_merges.py
+++ b/scripts/split_false_merges.py
@@ -41,10 +41,65 @@ COLLISION_PAIRS = [
     ("Locations/Esquimalt Harbour.md", "Locations/Esquimalt Lagoon.md"),
     ("Locations/Vancouver Island.md", "Locations/Vancouver.md"),
     ("Concepts/Bioregionalism.md", "Concepts/Bioregional Finance.md"),
+
+    # --- 2026-07-16 round ---------------------------------------------------
+    # Surfaced by auditing entity_rid_mappings for canonicals with >1 mapping.
+    # Only pairs that are DEMONSTRABLY two different real things are listed;
+    # same-thing duplicates (Will Reddick/Will Ruddick, Becca/Rebecca Harman,
+    # Claims Engine/Claims Engine V1, and the cross-type Org-vs-Project pairs)
+    # are note-duplication, not entity collisions — splitting those would
+    # fragment one real entity, so they are deliberately excluded.
+    ("Organizations/University of Victoria.md", "Organizations/University of Alberta.md"),           # Edmonton, ualberta.ca
+    ("Organizations/First Nations National Guardians Network.md", "Organizations/First Nations Finance Authority.md"),  # FNFA, fnfa.ca
+    ("Projects/Regen Ledger.md", "Concepts/REGEN Token.md"),                                          # the chain vs its native token
+    ("Projects/KOI.md", "People/Koi.md"),                                                             # KOI infra vs an unrelated person in Brazil
+    ("Projects/Claims Engine Demo Checklist.md", "Projects/Claims Engine Prod Runbook.md"),           # two distinct documents
 ]
 
 VAULT_ROOT = os.path.expanduser("~/Documents/Notes")
 API_BASE = "http://localhost:8351"
+
+
+def doc_rid_to_vault_path(doc_rid: str):
+    """Map a document_rid to a vault-relative .md path, or None if not a vault note.
+
+    Step 5 previously hard-coded `doc_rid.replace('orn:obsidian.document:Notes/', '')`.
+    Real document_rid prefixes are `vault:` (the dominant form for vault notes),
+    plus `orn:`, `document:`, `claude-session:` and `substack-corpus:` — so for
+    every `vault:`-prefixed rid the replace was a no-op, the resulting path never
+    existed, and the loop `continue`d. Step 5 therefore re-attributed NOTHING,
+    silently, for every split run to date (2026-07-16).
+
+    Only vault-backed notes are returned; non-vault sources (sessions, substack)
+    have no file to inspect for wikilinks.
+    """
+    for prefix in ("vault:", "orn:obsidian.document:Notes/", "orn:obsidian.note:Notes/"):
+        if doc_rid.startswith(prefix):
+            rel = doc_rid[len(prefix):]
+            return rel if rel.endswith(".md") else rel + ".md"
+    return None
+
+
+def update_note_canonical_uri(vault_path: str, old_uri: str, new_uri: str) -> bool:
+    """Repoint a note's koi.canonical_uri from old_uri to new_uri.
+
+    Step 6 used to only LOG the required change, so a split note kept advertising
+    the winner's URI in its own frontmatter (e.g. University of Alberta.md still
+    claimed organization-university-of-victoria-...). Rewrites only the exact
+    `canonical_uri: <old_uri>` line, and only when it still holds old_uri, so it
+    is idempotent and cannot touch anything else in the file.
+    """
+    path = os.path.join(VAULT_ROOT, vault_path)
+    if not os.path.exists(path):
+        return False
+    with open(path) as f:
+        content = f.read()
+    needle = f"canonical_uri: {old_uri}"
+    if needle not in content:
+        return False
+    with open(path, "w") as f:
+        f.write(content.replace(needle, f"canonical_uri: {new_uri}", 1))
+    return True
 
 
 def generate_uri(entity_type: str, name: str) -> str:
@@ -132,7 +187,7 @@ async def split_one(conn, pair, dry_run=False):
     logger.info(f"    New URI: {new_uri}")
 
     if dry_run:
-        return new_uri
+        return (old_uri, new_uri)
 
     # --- Phase B-I: Commit split mappings (single transaction) ---
     async with conn.transaction():
@@ -221,9 +276,9 @@ async def split_one(conn, pair, dry_run=False):
     entity_b_wikilink = entity_b_path.replace('.md', '')
     for link in doc_links:
         doc_rid = link['document_rid']
-        # Convert document_rid to vault path for file check
-        # orn:obsidian.document:Notes/Meetings/foo → Meetings/foo.md
-        doc_vault_path = doc_rid.replace('orn:obsidian.document:Notes/', '') + '.md'
+        doc_vault_path = doc_rid_to_vault_path(doc_rid)
+        if not doc_vault_path:
+            continue  # non-vault source (session/substack) — no file to inspect
         doc_filepath = os.path.join(VAULT_ROOT, doc_vault_path)
 
         if not os.path.exists(doc_filepath):
@@ -250,7 +305,7 @@ async def split_one(conn, pair, dry_run=False):
             """, doc_rid, new_uri)
             logger.info(f"    Moved doc link: {doc_rid} → new URI")
 
-    return new_uri
+    return (old_uri, new_uri)
 
 
 async def main():
@@ -263,19 +318,25 @@ async def main():
         results = {}
         for pair in COLLISION_PAIRS:
             logger.info(f"\n--- Splitting: {pair[0]} / {pair[1]} ---")
-            new_uri = await split_one(conn, pair, dry_run=dry_run)
-            if new_uri:
-                results[pair[1]] = new_uri
+            split = await split_one(conn, pair, dry_run=dry_run)
+            if split:
+                results[pair[1]] = split  # (old_uri, new_uri) — Step 6 needs both
 
         logger.info(f"\n{'=' * 60}")
         logger.info(f"Split complete. {len(results)} entities split.")
         if dry_run:
             logger.info("(DRY RUN — no changes made)")
 
-        # Output vault frontmatter updates needed
-        logger.info(f"\n--- Vault frontmatter updates needed (Step 6) ---")
-        for vault_path, new_uri in results.items():
-            logger.info(f"  {vault_path}: koi.canonical_uri → {new_uri}")
+        # Step 6: repoint each split note's koi.canonical_uri. Previously this
+        # only logged, leaving split notes advertising the winner's URI forever.
+        logger.info(f"\n--- Vault frontmatter updates (Step 6) ---")
+        for vault_path, (old_uri, new_uri) in results.items():
+            if dry_run:
+                logger.info(f"  [dry-run] {vault_path}: koi.canonical_uri → {new_uri}")
+            elif update_note_canonical_uri(vault_path, old_uri, new_uri):
+                logger.info(f"  {vault_path}: koi.canonical_uri → {new_uri}")
+            else:
+                logger.info(f"  {vault_path}: no koi.canonical_uri to update (skipped)")
 
         # Return results for programmatic use
         return results

--- a/tests/test_pick_best_mapping.py
+++ b/tests/test_pick_best_mapping.py
@@ -1,0 +1,229 @@
+"""Pure-unit tests for _pick_best_mapping — duplicate entity_rid_mappings (2026-07-16).
+
+No DB, no embeddings. Exercises the tiebreak that decides which vault note wins
+when several entity_rid_mappings rows share one canonical_uri.
+
+Why this exists — the Marie regression:
+
+    canonical person-marie-gauthier-1bb78735e78e had TWO mappings:
+      id 2257  Notes/Person/marie           -> People/Marie.md          (2026-03-13)
+      id 3465  Notes/Person/marie-gauthier  -> People/Marie Gauthier.md (2026-07-16)
+
+    People/Marie.md was a duplicate that had been deleted and then restored by
+    Obsidian Sync from a stale device. _annotate_vault_fields used a bare
+    `LIMIT 1` with no ORDER BY, so Postgres returned the older row and every
+    resolve_entity('Marie Gauthier') reported the loser's path — which meant
+    /process-note --propagate wrote mentionedIn into the wrong note.
+
+Duplicates are created by /register-entity itself: it upserts
+`ON CONFLICT (vault_rid)`, so registering a second note for an existing
+canonical INSERTs a new row instead of repointing the old one.
+"""
+
+import os
+import sys
+
+import pytest
+
+ROOT = os.path.join(os.path.dirname(__file__), "..")
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)
+
+from api import personal_ingest_api as api
+
+
+def row(vault_path, name, canonical_name):
+    return {"vault_path": vault_path, "name": name, "canonical_name": canonical_name}
+
+
+@pytest.fixture
+def only_survivor_on_disk(monkeypatch):
+    """People/Marie Gauthier.md exists; the restored duplicate does not."""
+    monkeypatch.setattr(
+        api, "_vault_note_exists", lambda p: p == "People/Marie Gauthier.md"
+    )
+
+
+@pytest.fixture
+def both_on_disk(monkeypatch):
+    """The sync-restored duplicate is back on disk alongside the survivor."""
+    monkeypatch.setattr(api, "_vault_note_exists", lambda p: True)
+
+
+def test_empty_rows_returns_none():
+    assert api._pick_best_mapping([]) is None
+    assert api._pick_best_mapping(None) is None
+
+
+def test_single_row_wins_even_if_missing_on_disk(monkeypatch):
+    """A lone mapping is still the answer — vault_note_exists reports the gap."""
+    monkeypatch.setattr(api, "_vault_note_exists", lambda p: False)
+    rows = [row("People/Ghost.md", "Ghost", "Ghost")]
+    assert api._pick_best_mapping(rows) == "People/Ghost.md"
+
+
+def test_prefers_note_that_exists_on_disk(only_survivor_on_disk):
+    """Existence beats recency: caller orders newest-first, loser is listed first."""
+    rows = [
+        row("People/Marie.md", "Marie", "Marie Gauthier"),
+        row("People/Marie Gauthier.md", "Marie Gauthier", "Marie Gauthier"),
+    ]
+    assert api._pick_best_mapping(rows) == "People/Marie Gauthier.md"
+
+
+def test_marie_regression_both_on_disk_name_match_wins(both_on_disk):
+    """THE regression: duplicate restored by sync, both files present.
+
+    Existence can't separate them, so the mapping whose name matches the
+    canonical entity name must win.
+    """
+    rows = [
+        row("People/Marie.md", "Marie", "Marie Gauthier"),
+        row("People/Marie Gauthier.md", "Marie Gauthier", "Marie Gauthier"),
+    ]
+    assert api._pick_best_mapping(rows) == "People/Marie Gauthier.md"
+
+
+def test_name_match_is_normalized(both_on_disk):
+    """Case/whitespace differences must not defeat the name match."""
+    rows = [
+        row("People/Marie.md", "Marie", "Marie Gauthier"),
+        row("People/Marie Gauthier.md", "  marie   GAUTHIER ", "Marie Gauthier"),
+    ]
+    assert api._pick_best_mapping(rows) == "People/Marie Gauthier.md"
+
+
+def test_existence_outranks_name_match(monkeypatch):
+    """A name-matching mapping to a deleted file loses to a live one.
+
+    Otherwise resolution points at a path that isn't there — the phantom class.
+    """
+    monkeypatch.setattr(api, "_vault_note_exists", lambda p: p == "People/Marie.md")
+    rows = [
+        row("People/Marie Gauthier.md", "Marie Gauthier", "Marie Gauthier"),
+        row("People/Marie.md", "Marie", "Marie Gauthier"),
+    ]
+    assert api._pick_best_mapping(rows) == "People/Marie.md"
+
+
+def test_recency_breaks_ties_when_nothing_else_separates(both_on_disk):
+    """Neither name matches the canonical → first row (newest) wins."""
+    rows = [
+        row("People/Newest.md", "Nope", "Marie Gauthier"),
+        row("People/Older.md", "Also Nope", "Marie Gauthier"),
+    ]
+    assert api._pick_best_mapping(rows) == "People/Newest.md"
+
+
+def test_vault_unmounted_is_fail_safe(monkeypatch):
+    """_vault_note_exists returns True for everything when the vault is absent.
+
+    The ranking must degrade to name-match, not discard every candidate.
+    """
+    monkeypatch.setattr(api, "_vault_note_exists", lambda p: True)
+    rows = [
+        row("People/Marie.md", "Marie", "Marie Gauthier"),
+        row("People/Marie Gauthier.md", "Marie Gauthier", "Marie Gauthier"),
+    ]
+    assert api._pick_best_mapping(rows) == "People/Marie Gauthier.md"
+
+
+def test_missing_canonical_name_does_not_crash(both_on_disk):
+    """LEFT JOIN can yield canonical_name=None; must not raise."""
+    rows = [
+        row("People/A.md", "A", None),
+        row("People/B.md", "B", None),
+    ]
+    assert api._pick_best_mapping(rows) == "People/A.md"
+
+
+def test_missing_mapping_name_does_not_crash(both_on_disk):
+    rows = [
+        row("People/A.md", None, "Marie Gauthier"),
+        row("People/Marie Gauthier.md", "Marie Gauthier", "Marie Gauthier"),
+    ]
+    assert api._pick_best_mapping(rows) == "People/Marie Gauthier.md"
+
+
+# --- expected_folder: same-name cross-type pairs -----------------------------
+#
+# Caught by measuring the fix against live data before shipping it: ranking on
+# (exists, name) alone TIED these pairs — both notes match the name — and fell
+# through to recency, which silently flipped Regenerate Cascadia from
+# Organizations/ (the survivor the 2026-06-30 consolidation chose) to Projects/.
+# The entity's own type is the tiebreak.
+
+
+def test_folder_match_beats_recency_regenerate_cascadia(both_on_disk):
+    """Regression: Organization entity must resolve to Organizations/.
+
+    Both notes name-match, and Projects/ is the more recently synced row (listed
+    first), so without expected_folder recency wins and picks the wrong note.
+    """
+    rows = [
+        row("Projects/Regenerate Cascadia.md", "Regenerate Cascadia", "Regenerate Cascadia"),
+        row("Organizations/Regenerate Cascadia.md", "Regenerate Cascadia", "Regenerate Cascadia"),
+    ]
+    assert (
+        api._pick_best_mapping(rows, expected_folder="Organizations")
+        == "Organizations/Regenerate Cascadia.md"
+    )
+
+
+def test_folder_match_koi_project_not_the_unrelated_person(both_on_disk):
+    """KOI (Project) must not resolve to People/Koi.md — a person in Brazil.
+
+    The live registry had all three mapped to canonical project-koi-c6f39042f013.
+    """
+    rows = [
+        row("People/Koi.md", "Koi", "KOI"),
+        row("Concepts/KOI.md", "KOI", "KOI"),
+        row("Projects/KOI.md", "KOI", "KOI"),
+    ]
+    assert (
+        api._pick_best_mapping(rows, expected_folder="Projects") == "Projects/KOI.md"
+    )
+
+
+def test_folder_match_pkols_organization(both_on_disk):
+    rows = [
+        row("Locations/PKOLS.md", "PKOLS", "PKOLS"),
+        row("Organizations/PKOLS.md", "PKOLS", "PKOLS"),
+    ]
+    assert (
+        api._pick_best_mapping(rows, expected_folder="Organizations")
+        == "Organizations/PKOLS.md"
+    )
+
+
+def test_expected_folder_none_falls_back_to_name_match(both_on_disk):
+    """No type hint → skip the folder signal, don't crash or discard rows."""
+    rows = [
+        row("People/Marie.md", "Marie", "Marie Gauthier"),
+        row("People/Marie Gauthier.md", "Marie Gauthier", "Marie Gauthier"),
+    ]
+    assert api._pick_best_mapping(rows, expected_folder=None) == "People/Marie Gauthier.md"
+
+
+def test_folder_prefix_is_not_a_substring_match(both_on_disk):
+    """'Projects' must not match 'ProjectsArchive/...'; only a real path segment."""
+    rows = [
+        row("ProjectsArchive/Thing.md", "Thing", "Thing"),
+        row("Projects/Thing.md", "Thing", "Thing"),
+    ]
+    assert api._pick_best_mapping(rows, expected_folder="Projects") == "Projects/Thing.md"
+
+
+def test_existence_still_outranks_folder_match(monkeypatch):
+    """A type-correct mapping to a deleted file loses to a live one."""
+    monkeypatch.setattr(
+        api, "_vault_note_exists", lambda p: p == "Organizations/SeaTrees.md"
+    )
+    rows = [
+        row("Projects/SeaTrees.md", "SeaTrees", "SeaTrees"),
+        row("Organizations/SeaTrees.md", "SeaTrees", "SeaTrees"),
+    ]
+    assert (
+        api._pick_best_mapping(rows, expected_folder="Projects")
+        == "Organizations/SeaTrees.md"
+    )


### PR DESCRIPTION
## Problem

`_annotate_vault_fields` picked the vault note for a resolved entity with a bare `LIMIT 1` and **no `ORDER BY`**, so when several `entity_rid_mappings` rows share one `canonical_uri`, Postgres returned an arbitrary (in practice oldest) row.

Duplicates are produced by `/register-entity` itself: the upsert conflicts on `vault_rid`, so registering a second note for an entity that already has one **INSERTs a new row rather than repointing the old one**, and nothing prunes the loser — it only emits a "URI collision" warning.

Found when `resolve_entity('Marie Gauthier')` kept returning `People/Marie.md` — a duplicate deleted in July and restored by Obsidian Sync from a stale device — instead of the live `People/Marie Gauthier.md`, so `/process-note --propagate` wrote `mentionedIn` into the wrong note.

Measured against the live registry, the old behaviour also resolved:

| Entity | Old resolution |
|---|---|
| `Will Ruddick` (Person) | `People/Will Reddick.md` — an ASR-typo note |
| `Andrew Millison` (Person) | `People/Andrew Millicent.md` |
| `KOI` (Project) | `People/Koi.md` — an unrelated person in Brazil |

`University of Victoria` and `Rebecca Harman` resolved correctly only by luck of physical row order.

## Fix

`_pick_best_mapping()` ranks candidates, highest first:

1. the note **exists on disk**;
2. the note is in the **folder for the entity's own type**;
3. the mapping's **name matches the canonical entity name**;
4. most recently synced.

**Signal (2) was added after measuring the first cut against live data.** Ranking on `(exists, name)` alone tied same-name cross-type pairs — both notes match the name — and fell through to recency, which silently flipped `Regenerate Cascadia` from `Organizations/` (the survivor chosen by the 2026-06-30 consolidation) to `Projects/`, and `PKOLS` from `Organizations/` to `Locations/`. Both signals are needed and are independent: Marie's duplicates share a folder and differ by name; Regenerate Cascadia's share a name and differ by folder.

Both degrade safely — `_vault_note_exists` returns `True` for every row when the vault isn't mounted (headless deploys), and `expected_folder=None` simply skips (2), so the ranking falls back to name-match then recency rather than discarding every candidate.

`/register-entity` additionally prunes sibling mappings for the same canonical **whose note no longer exists**. Two *live* notes on one canonical is a real operator ambiguity (already surfaced as the collision warning), not something to resolve by silent deletion. `document_entity_links` hang off `canonical_uri` rather than these rows, so pruning cannot drop links.

## Tests

`tests/test_pick_best_mapping.py` — 17 pure-unit cases (no DB): the Marie regression, the Regenerate Cascadia / PKOLS / KOI cross-type cases, precedence between each signal, the unmounted-vault fallback, folder-prefix not matching on a substring, and the `LEFT JOIN`'s nullable columns.

`49 passed` together with the existing `tests/test_resolver_guards.py`. Verified live against the running personal-koi service after restart.

## Not included

51 duplicate groups remain in the local registry. Those are **entity-identity** bad merges (two real things sharing one canonical — e.g. `University of Victoria` + `University of Alberta`, `Regen Ledger` + `REGEN Token`, whole meeting/task series collapsed onto one entity). They need *splitting* (new URI + moving doc links and facts, the shape `scripts/split_false_merges.py` implements), not mapping pruning, and each needs a judgement call. This PR neutralises the resolution harm — the ranking returns the correct note in every case — but does not merge or split any entities.